### PR TITLE
docs: align command catalog with repository inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of production-ready slash commands for [Claude Code](
 
 ## Overview
 
-This repository provides **56 production-ready slash commands** (15 workflows, 41 tools) that extend Claude Code's capabilities through:
+This repository provides **57 production-ready slash commands** (15 workflows, 42 tools) that extend Claude Code's capabilities through:
 
 - **Workflows**: Multi-agent orchestration systems that coordinate complex, multi-step operations across different domains
 - **Tools**: Specialized single-purpose utilities for focused development tasks
@@ -78,7 +78,6 @@ Workflows implement multi-agent orchestration patterns for complex, cross-domain
 | `git-workflow` | Version control process automation | Branching strategies, commit standards, PR templates |
 | `improve-agent` | Agent optimization | Prompt engineering, performance tuning |
 | `legacy-modernize` | Codebase modernization | Architecture migration, dependency updates, pattern refactoring |
-| `ml-pipeline` | Machine learning pipeline construction | Data engineering, model training, deployment |
 | `multi-platform` | Cross-platform development | Web, mobile, desktop coordination |
 | `workflow-automate` | CI/CD pipeline automation | Build, test, deploy, monitor |
 
@@ -92,19 +91,26 @@ Workflows implement multi-agent orchestration patterns for complex, cross-domain
 | `performance-optimization` | System-wide optimization | Profiling, caching, query optimization, load testing |
 | `incident-response` | Production issue resolution | Diagnostics, root cause analysis, hotfix deployment |
 
-### Tools (41 commands)
+### Tools (42 commands)
 
 Tools provide focused, single-purpose utilities for specific development operations. Each tool is optimized for its domain with production-ready implementations.
 
-#### AI and Machine Learning (5 tools)
+#### AI and Machine Learning (4 tools)
 
 | Command | Functionality | Key Features |
 |---------|--------------|--------------|
 | `ai-assistant` | AI assistant implementation | LLM integration, conversation management, context handling |
 | `ai-review` | ML code review | Model architecture validation, training pipeline review |
 | `langchain-agent` | LangChain agent creation | RAG patterns, tool integration, memory management |
-| `ml-pipeline` | ML pipeline construction | Data processing, training, evaluation, deployment |
 | `prompt-optimize` | Prompt engineering | Performance testing, cost optimization, quality metrics |
+
+#### Agent Collaboration (3 tools)
+
+| Command | Focus | Highlights |
+|---------|-------|-----------|
+| `multi-agent-review` | Multi-perspective code reviews | Architecture, security, and quality assessments |
+| `multi-agent-optimize` | Coordinated performance optimization | Database, application, and frontend tuning |
+| `smart-debug` | Assisted debugging | Root-cause analysis with performance-aware escalation |
 
 #### Architecture and Code Quality (4 tools)
 
@@ -123,7 +129,7 @@ Tools provide focused, single-purpose utilities for specific development operati
 | `data-validation` | Data quality | Schema validation, anomaly detection, constraint checking |
 | `db-migrate` | Database migrations | Schema versioning, zero-downtime strategies, rollback plans |
 
-#### DevOps and Infrastructure (6 tools)
+#### DevOps and Infrastructure (5 tools)
 
 | Command | Domain | Implementation |
 |---------|--------|----------------|
@@ -132,7 +138,6 @@ Tools provide focused, single-purpose utilities for specific development operati
 | `k8s-manifest` | Kubernetes configuration | Deployments, services, ingress, autoscaling, security policies |
 | `monitor-setup` | Observability | Metrics, logging, tracing, alerting rules |
 | `slo-implement` | SLO/SLI definition | Error budgets, monitoring, automated responses |
-| `workflow-automate` | Pipeline automation | CI/CD, GitOps, infrastructure as code |
 
 #### Testing and Development (6 tools)
 

--- a/tools/ai-assistant.md
+++ b/tools/ai-assistant.md
@@ -67,9 +67,11 @@ class AIAssistantArchitecture:
                 ],
                 'implementation': '''
 class IntentClassifier:
-    def __init__(self, model_path: str):
+    def __init__(self, model_path: str, *, config: Optional[Dict[str, Any]] = None):
         self.model = self.load_model(model_path)
         self.intents = self.load_intent_schema()
+        default_config = {"threshold": 0.65}
+        self.config = {**default_config, **(config or {})}
     
     async def classify(self, text: str) -> Dict[str, Any]:
         # Preprocess text

--- a/tools/issue.md
+++ b/tools/issue.md
@@ -7,14 +7,14 @@ Please analyze and fix the GitHub issue: $ARGUMENTS.
 Follow these steps:
 
 # PLAN
-1. Use 'gh issue view' to get the issue details
+1. Use 'gh issue view' to get the issue details (or open the issue in the browser/API explorer if the GitHub CLI is unavailable)
 2. Understand the problem described in the issue
 3. Ask clarifying questions if necessary
 4. Understand the prior art for this issue
 - Search the scratchpads for previous thoughts related to the issue
 - Search PRs to see if you can find history on this issue
 - Search the codebase for relevant files
-5. Think harder about how to break the issue down into a seriers of small, manageable tasks.
+5. Think harder about how to break the issue down into a series of small, manageable tasks.
 6. Document your plan in a new scratchpad
   - include the issue name in the filename
   - include a link to the issue in the scratchpad.
@@ -34,4 +34,4 @@ Follow these steps:
 # DEPLOY
 - Open a PR and request a review.
 
-Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.
+Prefer the GitHub CLI (`gh`) for GitHub-related tasks, but fall back to Claude subagents or the GitHub web UI/REST API when the CLI is not installed.

--- a/tools/standup-notes.md
+++ b/tools/standup-notes.md
@@ -11,6 +11,12 @@ Generate daily standup notes by reviewing Obsidian vault context and Jira ticket
 /standup-notes
 ```
 
+## Prerequisites
+
+- Enable the **mcp-obsidian** provider with read/write access to the target vault.
+- Configure the **atlassian** provider with Jira credentials that can query the team's backlog.
+- Optional: connect calendar integrations if you want meetings to appear automatically.
+
 ## Process
 
 1. **Gather Context from Obsidian**
@@ -19,7 +25,7 @@ Generate daily standup notes by reviewing Obsidian vault context and Jira ticket
    - Look for project updates, completed tasks, and ongoing work
 
 2. **Check Jira Tickets**
-   - Use `mcp__atlassian__searchJiraIssuesUsingJql` to find tickets assigned to current user
+   - Use `mcp__atlassian__searchJiraIssuesUsingJql` to find tickets assigned to current user (fall back to asking the user for updates if the Atlassian connector is unavailable)
    - Filter for:
      - In Progress tickets (current work)
      - Recently resolved/closed tickets (yesterday's accomplishments)
@@ -44,8 +50,8 @@ Generate daily standup notes by reviewing Obsidian vault context and Jira ticket
    ```
 
 4. **Write to Obsidian**
-   - Create file in `Standup Notes/YYYY-MM-DD.md` format
-   - Use `mcp__mcp-obsidian__obsidian_append_content` to write the generated notes
+   - Create file in `Standup Notes/YYYY-MM-DD.md` format (or summarize in the chat if the Obsidian connector is disabled)
+   - Use `mcp__mcp-obsidian__obsidian_append_content` to write the generated notes when available
 
 ## Implementation Steps
 


### PR DESCRIPTION
## Summary
- update the README command counts and tables to match the current set of workflow and tool files
- document connector prerequisites and fallbacks for the standup notes tool
- clarify GitHub CLI fallbacks and fix the intent classifier configuration example

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d893b563008332a64d902689b681d3